### PR TITLE
Changed ENV env var to ENVIRONMENT as ENV isn't being picked up in CKAN plugins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
-ENV=dev
+# This environment
+ENVIRONMENT=dev
 
 # DB image settings
 POSTGRES_PASSWORD=ckan

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 include $(PWD)/.env
 
-ifeq ($(ENV), dev)
+ifeq ($(ENVIRONMENT), dev)
 all:
 COMPOSE_FILE_PATH := docker-compose.dev.yml
 else


### PR DESCRIPTION
This is necessary to report the correct environment in the Senty CKAN plugin