### PR TITLE
Consistent docker compose behaviour

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,55 +9,55 @@ else # Production
 endif
 
 build.all:
-	docker-compose $(COMPOSE_FILE_PATH) build --no-cache
+	docker compose $(COMPOSE_FILE_PATH) build --no-cache
 
 build.ckan:
-	docker-compose $(COMPOSE_FILE_PATH) build --no-cache ckan
+	docker compose $(COMPOSE_FILE_PATH) build --no-cache ckan
 
 rebuild.ckan:
-	docker-compose $(COMPOSE_FILE_PATH) up -d --no-deps --build ckan
+	docker compose $(COMPOSE_FILE_PATH) up -d --no-deps --build ckan
 
 restart.ckan:
-	docker-compose $(COMPOSE_FILE_PATH) up -d --no-deps --force-recreate ckan
+	docker compose $(COMPOSE_FILE_PATH) up -d --no-deps --force-recreate ckan
 
 replace.ckan:
 	./update_ckan_container.sh
 
 scaleup.ckan:
-	docker-compose $(COMPOSE_FILE_PATH) up -d --no-deps --scale ckan=2 --no-recreate ckan
+	docker compose $(COMPOSE_FILE_PATH) up -d --no-deps --scale ckan=2 --no-recreate ckan
 
 scaledown.ckan:
-	docker-compose $(COMPOSE_FILE_PATH) up -d --no-deps --scale ckan=1 --no-recreate ckan
+	docker compose $(COMPOSE_FILE_PATH) up -d --no-deps --scale ckan=1 --no-recreate ckan
 
 start: up logs
 
 up:
-	docker-compose $(COMPOSE_FILE_PATH) up -d
+	docker compose $(COMPOSE_FILE_PATH) up -d
 
 down:
-	docker-compose $(COMPOSE_FILE_PATH) down
+	docker compose $(COMPOSE_FILE_PATH) down
 
 logs:
-	docker-compose $(COMPOSE_FILE_PATH) logs -f
+	docker compose $(COMPOSE_FILE_PATH) logs -f
 
 ps: 
-	docker-compose $(COMPOSE_FILE_PATH) ps
+	docker compose $(COMPOSE_FILE_PATH) ps
 	
 reload.caddy:
-	docker-compose ${COMPOSE_FILE_PATH} exec -w /etc/caddy caddy caddy reload
+	docker compose ${COMPOSE_FILE_PATH} exec -w /etc/caddy caddy caddy reload
 
 harvest.gather:
-	docker-compose $(COMPOSE_FILE_PATH) exec ckan /bin/bash -c "ckan harvester gather_consumer"
+	docker compose $(COMPOSE_FILE_PATH) exec ckan /bin/bash -c "ckan harvester gather_consumer"
 
 harvest.fetch:
-	docker-compose $(COMPOSE_FILE_PATH) exec ckan /bin/bash -c "ckan harvester fetch_consumer"
+	docker compose $(COMPOSE_FILE_PATH) exec ckan /bin/bash -c "ckan harvester fetch_consumer"
 
 harvest.run:
-	docker-compose $(COMPOSE_FILE_PATH) exec ckan /bin/bash -c "ckan harvester run"
+	docker compose $(COMPOSE_FILE_PATH) exec ckan /bin/bash -c "ckan harvester run"
 
 xloader.submit:
-	docker-compose $(COMPOSE_FILE_PATH) exec ckan /bin/bash -c "ckan xloader submit all"
+	docker compose $(COMPOSE_FILE_PATH) exec ckan /bin/bash -c "ckan xloader submit all"
 
 # WIP currently having issues running this locally
 test.plugins:
-	docker-compose $(COMPOSE_FILE_PATH) exec -w "/srv/app/src_extensions/ckanext-subakdc-plugins" ckan /bin/bash -c "pip install pytest-ckan requests_mock && pytest --ckan-ini=test.ini"
+	docker compose $(COMPOSE_FILE_PATH) exec -w "/srv/app/src_extensions/ckanext-subakdc-plugins" ckan /bin/bash -c "pip install pytest-ckan requests_mock && pytest --ckan-ini=test.ini"


### PR DESCRIPTION
Locally I'm using docker-compose v2.x.x but the servers were using v1.x.x which was causing issues with the scaling up and down of the CKAN containers on deploy.

This PR updates the Makefile so that the servers use `docker compose ...` instead of `docker-compose ...` which has now been removed from the servers.