### PR TITLE
[IN PROGRESS] Facet search on custom fields (country, region, start date, end date)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,8 @@ qa.run:
 search.reindex:
 	docker exec $(CKAN_CONTAINER) /bin/bash -c "ckan search-index rebuild"
 
+dev:
+	cd src/ckanext-subakdc && npm run dev
 
 # WIP currently having issues running this locally
 test.plugins:

--- a/solr8/ckan_init_solr.sh
+++ b/solr8/ckan_init_solr.sh
@@ -8,11 +8,12 @@
 
 set -e
 
-CKAN_SOLR_SCHEMA_URL=https://raw.githubusercontent.com/ckan/ckan/$CKAN_VERSION/ckan/config/solr/schema.solr8.xml 
+# CKAN_SOLR_SCHEMA_URL=https://raw.githubusercontent.com/ckan/ckan/$CKAN_VERSION/ckan/config/solr/schema.solr8.xml 
+CKAN_SOLR_SCHEMA_URL=/tmp/schema.xml
 
 echo "Check whether managed schema exists for CKAN $CKAN_VERSION"
-if ! curl --output /dev/null --silent --head --fail "$CKAN_SOLR_SCHEMA_URL"; then
-  echo "Can't find CKAN SOLR schema at URL: $CKAN_SOLR_SCHEMA_URL. Exiting..."
+if ! cp $CKAN_SOLR_SCHEMA_URL /dev/null; then
+  echo "Can't find or move CKAN SOLR schema locally: $CKAN_SOLR_SCHEMA_URL. Exiting..."
   exit 1
 fi
 
@@ -32,7 +33,7 @@ else
     
     # Replace the managed schema with CKANs schema
     echo "Adding CKAN managed schema"
-    curl $CKAN_SOLR_SCHEMA_URL -o /var/solr/data/$CKAN_CORE_NAME/conf/managed-schema -s
+    cp $CKAN_SOLR_SCHEMA_URL /var/solr/data/$CKAN_CORE_NAME/conf/managed-schema
     
     echo "SOLR initialized"
 fi

--- a/solr8/schema.xml
+++ b/solr8/schema.xml
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!--
+     NB Please copy changes to this file into the multilingual schema:
+        ckanext/multilingual/solr/schema.xml
+-->
+
+<!-- We update the version when there is a backward-incompatible change to this
+schema. We used to use the `version` attribute for this but this is an internal
+attribute that should not be used so starting from CKAN 2.10 we use the `name`
+attribute with the form `ckan-X.Y` -->
+
+<!-- 
+  This schema is taken and adapted from
+  https://raw.githubusercontent.com/ckan/ckan/2.9/ckan/config/solr/schema.solr8.xml
+
+  Adapted by Subak for custom fields using ckanext-scheming, with help from this issue
+  https://github.com/ckan/ckanext-scheming/issues/195
+-->
+<schema name="ckan-2.10" version="1.6">
+
+<types>
+    <fieldType name="string" class="solr.StrField" sortMissingLast="true" omitNorms="true"/>
+    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true" omitNorms="true"/>
+    <fieldtype name="binary" class="solr.BinaryField"/>
+    <fieldType name="int" class="solr.IntPointField" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="float" class="solr.FloatPointField" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="long" class="solr.LongPointField" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="double" class="solr.DoublePointField" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="pint" class="solr.IntPointField" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="pfloat" class="solr.FloatPointField" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="plong" class="solr.LongPointField" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="pdouble" class="solr.DoublePointField" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="date" class="solr.DatePointField" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="pdate" class="solr.DatePointField" omitNorms="true" positionIncrementGap="0"/>
+
+    <fieldType name="pdates" class="solr.DatePointField" positionIncrementGap="0" multiValued="true"/>
+    <fieldType name="booleans" class="solr.BoolField" sortMissingLast="true" multiValued="true"/>
+    <fieldType name="pints" class="solr.IntPointField" positionIncrementGap="0" multiValued="true"/>
+    <fieldType name="pfloats" class="solr.FloatPointField" positionIncrementGap="0" multiValued="true"/>
+    <fieldType name="plongs" class="solr.LongPointField" positionIncrementGap="0" multiValued="true"/>
+    <fieldType name="pdoubles" class="solr.DoublePointField" positionIncrementGap="0" multiValued="true"/>
+
+    <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
+        <analyzer type="index">
+            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
+            <filter class="solr.FlattenGraphFilterFactory"/> <!-- required on index analyzers after graph filters -->
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.SnowballPorterFilterFactory" language="English" protected="protwords.txt"/>
+            <filter class="solr.ASCIIFoldingFilterFactory"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.SnowballPorterFilterFactory" language="English" protected="protwords.txt"/>
+            <filter class="solr.ASCIIFoldingFilterFactory"/>
+        </analyzer>
+    </fieldType>
+
+
+    <!-- A general unstemmed text field - good if one does not know the language of the field -->
+    <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100">
+        <analyzer type="index">
+            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="0"/>
+            <filter class="solr.FlattenGraphFilterFactory"/> <!-- required on index analyzers after graph filters -->
+            <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="0"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
+    </fieldType>
+
+    <fieldType name="text_ngram" class="solr.TextField" positionIncrementGap="100">
+      <analyzer type="index">
+        <tokenizer class="solr.NGramTokenizerFactory" minGramSize="2" maxGramSize="10"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
+</types>
+
+
+<fields>
+    <field name="index_id" type="string" indexed="true" stored="true" required="true" />
+    <field name="id" type="string" indexed="true" stored="true" required="true" />
+    <field name="site_id" type="string" indexed="true" stored="true" required="true" />
+    <field name="title" type="text" indexed="true" stored="true" />
+    <field name="title_ngram" type="text_ngram" indexed="true" stored="true" />
+    <field name="entity_type" type="string" indexed="true" stored="true" omitNorms="true" />
+    <field name="dataset_type" type="string" indexed="true" stored="true" />
+    <field name="state" type="string" indexed="true" stored="true" omitNorms="true" />
+    <field name="name" type="string" indexed="true" stored="true" omitNorms="true" />
+    <field name="name_ngram" type="text_ngram" indexed="true" stored="true" />
+    <field name="revision_id" type="string" indexed="true" stored="true" omitNorms="true" />
+    <field name="version" type="string" indexed="true" stored="true" />
+    <field name="url" type="string" indexed="true" stored="true" omitNorms="true" />
+    <field name="ckan_url" type="string" indexed="true" stored="true" omitNorms="true" />
+    <field name="download_url" type="string" indexed="true" stored="true" omitNorms="true" />
+    <field name="notes" type="text" indexed="true" stored="true"/>
+    <field name="author" type="text_general" indexed="true" stored="true" />
+    <field name="author_email" type="text_general" indexed="true" stored="true" />
+    <field name="maintainer" type="text_general" indexed="true" stored="true" />
+    <field name="maintainer_email" type="text_general" indexed="true" stored="true" />
+    <field name="license" type="string" indexed="true" stored="true" />
+    <field name="license_id" type="string" indexed="true" stored="true" />
+    <field name="tags" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="groups" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="organization" type="string" indexed="true" stored="true" multiValued="false"/>
+
+    <field name="capacity" type="string" indexed="true" stored="true" multiValued="false"/>
+    <field name="permission_labels" type="string" indexed="true" stored="false" multiValued="true"/>
+
+    <field name="res_name" type="text_general" indexed="true" stored="true" multiValued="true" />
+    <field name="res_description" type="text_general" indexed="true" stored="true" multiValued="true"/>
+    <field name="res_format" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="res_url" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="res_type" type="string" indexed="true" stored="true" multiValued="true"/>
+
+    <!-- catchall field, containing all other searchable text fields (implemented
+         via copyField further on in this schema  -->
+    <field name="text" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="urls" type="text" indexed="true" stored="false" multiValued="true"/>
+
+    <field name="depends_on" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="dependency_of" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="derives_from" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="has_derivation" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="links_to" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="linked_from" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="child_of" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="parent_of" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="views_total" type="int" indexed="true" stored="false"/>
+    <field name="views_recent" type="int" indexed="true" stored="false"/>
+    <field name="resources_accessed_total" type="int" indexed="true" stored="false"/>
+    <field name="resources_accessed_recent" type="int" indexed="true" stored="false"/>
+
+    <field name="metadata_created" type="date" indexed="true" stored="true" multiValued="false"/>
+    <field name="metadata_modified" type="date" indexed="true" stored="true" multiValued="false"/>
+
+    <field name="indexed_ts" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
+
+    <!-- Copy the title field into titleString, and treat as a string
+         (rather than text type).  This allows us to sort on the titleString -->
+    <field name="title_string" type="string" indexed="true" stored="false" />
+
+    <field name="data_dict" type="string" indexed="false" stored="true" />
+    <field name="validated_data_dict" type="string" indexed="false" stored="true" />
+
+    <field name="_version_" type="string" indexed="true" stored="true"/>
+
+    <dynamicField name="*_date" type="date" indexed="true" stored="true" multiValued="false"/>
+
+    <dynamicField name="extras_*" type="text" indexed="true" stored="true" multiValued="false"/>
+    <dynamicField name="res_extras_*" type="text" indexed="true" stored="true" multiValued="true"/>
+    <dynamicField name="vocab_*" type="string" indexed="true" stored="true" multiValued="true"/>
+    <dynamicField name="*" type="string" indexed="true"  stored="false"/>
+
+    <!-- Extra Subak fields -->
+    <field name="subak_overview" type="string" indexed="true" stored="true"/>
+    <field name="subak_geo_region" type="string" indexed="true" stored="true" multiValued="false"/>
+    <field name="subak_countries" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="subak_temporal_start" type="date" indexed="true" stored="true" multiValued="false" docValues="true"/>
+    <field name="subak_temporal_end" type="date" indexed="true" stored="true" multiValued="false" docValues="true"/>
+    <field name="subak_temporal_resolution" type="string" indexed="true" stored="true" multiValued="false"/>
+    <field name="subak_spatial_resolution" type="string" indexed="true" stored="true" multiValued="false"/>
+    <field name="subak_update_frequency" type="string" indexed="true" stored="true" multiValued="false"/>
+</fields>
+
+<uniqueKey>index_id</uniqueKey>
+
+<copyField source="url" dest="urls"/>
+<copyField source="title" dest="title_ngram"/>
+<copyField source="name" dest="name_ngram"/>
+<copyField source="ckan_url" dest="urls"/>
+<copyField source="download_url" dest="urls"/>
+<copyField source="res_url" dest="urls"/>
+<copyField source="extras_*" dest="text"/>
+<copyField source="res_extras_*" dest="text"/>
+<copyField source="vocab_*" dest="text"/>
+<copyField source="urls" dest="text"/>
+<copyField source="name" dest="text"/>
+<copyField source="title" dest="text"/>
+<copyField source="text" dest="text"/>
+<copyField source="license" dest="text"/>
+<copyField source="notes" dest="text"/>
+<copyField source="tags" dest="text"/>
+<copyField source="groups" dest="text"/>
+<copyField source="organization" dest="text"/>
+<copyField source="res_name" dest="text"/>
+<copyField source="res_description" dest="text"/>
+<copyField source="maintainer" dest="text"/>
+<copyField source="author" dest="text"/>
+
+</schema>

--- a/src/ckanext-subakdc-plugins/ckanext/schema/plugin.py
+++ b/src/ckanext-subakdc-plugins/ckanext/schema/plugin.py
@@ -5,19 +5,54 @@ import ckan.plugins as p
 
 log = logging.getLogger(__name__)
 
-def get_countries_dict(field):
-    with open(path.join(path.dirname(__file__), 'countries-iso-3166.json')) as f:
+
+def get_countries_dict():
+    with open(path.join(path.dirname(__file__), "countries-iso-3166.json")) as f:
         countries = json.load(f)
-        
-    return list(map(lambda c: { 'value': c['alpha-2'], 'label': c['name'] }, countries))
+
+    return list(map(lambda c: {"value": c["alpha-2"], "label": c["name"]}, countries))
+
+
+def get_country_name_from_code(code):
+    with open(path.join(path.dirname(__file__), "countries-iso-3166.json")) as f:
+        countries = json.load(f)
+    codes_to_names = {c["alpha-2"]: c["name"] for c in countries}
+    if code == "[]" or code is None:
+        return None
+    return codes_to_names[code]
+
 
 class SchemaPlugin(p.SingletonPlugin):
     p.implements(p.ITemplateHelpers)
-    
+    p.implements(p.IFacets, inherit=True)
+    p.implements(p.IPackageController, inherit=True)
+
     # ------- ITemplateHelpers method implementations ------- #
-    
+
     def get_helpers(self):
-        ''' 
+        """
         Helper function to extract the freshness score from the package dict
-        '''
-        return {'scheming_countries_choices': get_countries_dict}
+        """
+        helpers = {
+            "scheming_countries_choices": get_countries_dict,
+            "scheming_code_to_name": get_country_name_from_code,
+        }
+        return helpers
+
+    # ------- IFacets method implementations ------- #
+    def dataset_facets(self, facets_dict, package_type):
+        """
+        Adds custom facets from schema to search facets
+        """
+        facets_dict["subak_countries"] = "Country"
+        facets_dict["subak_geo_region"] = "Region"
+        facets_dict["subak_temporal_start"] = "Earliest Date"
+        facets_dict["subak_temporal_end"] = "Latest Date"
+        return facets_dict
+
+    # ------- IPackageController method implementations ------- #
+    def before_index(self, data_dict):
+        data_dict["subak_countries"] = json.loads(
+            data_dict.get("subak_countries", "[]")
+        )
+        return data_dict

--- a/src/ckanext-subakdc-plugins/setup.py
+++ b/src/ckanext-subakdc-plugins/setup.py
@@ -87,6 +87,7 @@ setup(
         freshness=ckanext.freshness.plugin:FreshnessPlugin
         schema=ckanext.schema.plugin:SchemaPlugin
         qa=ckanext.qa.plugin:QAPlugin
+        search=ckanext.search.plugin:SearchPlugin
 
         [babel.extractors]
         ckan = ckan.lib.extract:extract_ckan

--- a/src/ckanext-subakdc/ckanext/subakdc/templates/snippets/facet_list.html
+++ b/src/ckanext-subakdc/ckanext/subakdc/templates/snippets/facet_list.html
@@ -82,10 +82,10 @@ Dictionary with search facets(or `c.search_facets` if not provided)
 								'bg-subak-sky-blue' if title=='Groups' else 
 								'bg-subak-meadow-teal' if title=='Tags' else 
 								'bg-subak-purple-rain' if title=='Formats' else 
-								'bg-subak-marine-blue' if title=='Licenses' }}">
+								'bg-subak-marine-blue' }}">
 						{% endif %}
 						<a href="{{ href }}" title="{{ label if label != label_truncated else '' }}" class="hover:no-underline">
-							<span class="p-1 text-white item-label">{{ label_truncated }}</span>
+							<span class="p-1 text-white item-label">{{ label_truncated if title != 'Country' else h.truncate(h.scheming_code_to_name(label)) }}</span>
 							<span class="hidden separator"> - </span>
 							<span class="item-count badge">{{ count }}</span>
 						</a>
@@ -99,7 +99,7 @@ Dictionary with search facets(or `c.search_facets` if not provided)
 		{% if h.get_param_int('_%s_limit' % name) %}
 		{% if h.has_more_facets(name, search_facets or c.search_facets) %}
 		<a href="{{ h.remove_url_param('_%s_limit' % name, replace=0, extras=extras, alternative_url=alternative_url) }}"
-			class="read-more">{{ _('Show More {facet_type}').format(facet_type=title) }}</a>
+			class="read-more">{{ _('Show More {facet_type}').format(facet_type=title) if title != 'Country' else 'Show More Countries'}}</a>
 		{% endif %}
 		{% else %}
 		<a href="{{ h.remove_url_param('_%s_limit' % name, extras=extras, alternative_url=alternative_url) }}"


### PR DESCRIPTION
This change requires (probably - seemed to locally) deleting the docker solr volume and then rebuilding the search index. 
If the volume isn't deleted, I'm unsure the solr core that was already created is updated properly with the new schema.

- Adds solr schema into the repo, as we need to add custom fields (under `<!-- Extra Subak fields -->`)
  - Countries gets `multiValued="True"` alone for now. 
  - Date fields are `class="solr.DatePointField"` as defined in `<types>` at top of the file. PointFields seem to need `docValues=true` or errors happen:
  - `<field name="subak_temporal_end" type="date" indexed="true" stored="true" multiValued="false" docValues="true"/>`
 
- The solr script is updated to copy in the schema file locally rather than pulling from remote url using curl.
 
- Templates are then updated to use the custom plugin helper for converting the country value to the label.

TODO: 
[ ] defining date ranges for date searches.