### PR TITLE
Added ability to run CKAN with pdb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ rebuild.ckan:
 restart.ckan:
 	docker compose $(COMPOSE_FILE_PATH) up -d --no-deps --force-recreate ckan
 
+debug.ckan:
+	docker stop ${CKAN_CONTAINER} && docker compose $(COMPOSE_FILE_PATH) run --rm --no-deps --name ckan ckan
+
 replace.ckan:
 	./update_ckan_container.sh
 

--- a/ckan-dev/2.9/setup/start_ckan_development.sh
+++ b/ckan-dev/2.9/setup/start_ckan_development.sh
@@ -78,4 +78,5 @@ fi
 supervisord --configuration /etc/supervisord.conf &
 
 # Start the development server with automatic reload
-sudo -u ckan -EH ckan -c $CKAN_INI run -H 0.0.0.0
+# sudo -u ckan -EH ckan -c $CKAN_INI run -H 0.0.0.0
+sudo -u ckan -EH python3 -m pdb ckan -c $CKAN_INI run -H 0.0.0.0


### PR DESCRIPTION
Run the stack as usual and then run `make debug.ckan` which will bring down the running CKAN instance and run CKAN with pdb enabled.

Simply add `import pdb; pdb.set_trace()` to add a breakpoint in your code.