### PR TITLE
BUGFIX on package update

### DIFF
--- a/src/ckanext-subakdc-plugins/ckanext/qa/plugin.py
+++ b/src/ckanext-subakdc-plugins/ckanext/qa/plugin.py
@@ -5,34 +5,40 @@ from ckanext.report.interfaces import IReport
 from ckanext.qa import tasks, reports, helpers
 from ckanext.qa.cli import get_commands
 from ckanext.qa.qa import QaTaskRunner
+
+
+def run_qa_tasks_on_package(pkg):
+    runner = QaTaskRunner(list(tasks.values()))
+    func = runner.run_on_single_package
+    tk.enqueue_job(func, [pkg.get("id")])
+
+
 class QAPlugin(p.SingletonPlugin, tk.DefaultDatasetForm):
     p.implements(p.IClick)
     p.implements(p.IConfigurer)
     p.implements(p.ITemplateHelpers)
     p.implements(p.IPackageController, inherit=True)
     p.implements(IReport)
-        
+
     # ------- IClick method implementations ------- #
     def get_commands(self):
         return get_commands()
 
     # ------- IConfigurer method implementations ------- #
     def update_config(self, config):
-        tk.add_template_directory(config, 'templates')
-    
+        tk.add_template_directory(config, "templates")
+
     # ------- ITemplateHelpers method implementations ------- #
     def get_helpers(self):
         return helpers
-        
+
     # ------- IPackageController method implementations ------- #
     def after_create(self, context, pkg_dict):
-        runner = QaTaskRunner(tasks.values())
-        runner.run_on_single_package(pkg_dict)
-        
+        run_qa_tasks_on_package(pkg_dict)
+
     def after_update(self, context, pkg_dict):
-        runner = QaTaskRunner(tasks.values())
-        runner.run_on_single_package(pkg_dict)
-        
+        run_qa_tasks_on_package(pkg_dict)
+
     # ------- IReport method implementations ------- #
     def register_reports(self):
         return reports


### PR DESCRIPTION
Finally solved!!

The way that CKAN implements the `after_update` hook is a bit broken as it doesn't commit the initial update to the DB before calling the update hook in plugins. So when the hook runs and tries to update the DB, the state of the DB and the update are out of sync causing the ObjectDeletedError in sqlalchemy.

I've got round this by forcing our hook to run as a job, ensuring that the initial update is fully completed before running QA tasks on the updated package.