### PR TITLE
Removed social links and moved license to main metadata info (+ some …

### DIFF
--- a/src/ckanext-subakdc/ckanext/subakdc/assets/css/tailwind.css
+++ b/src/ckanext-subakdc/ckanext/subakdc/assets/css/tailwind.css
@@ -1550,6 +1550,10 @@ Ensure the default browser behavior of the `hidden` attribute.
   --tw-bg-opacity: 1 !important;
   background-color: rgb(244 244 245 / var(--tw-bg-opacity)) !important;
 }
+.bg-green-500 {
+  --tw-bg-opacity: 1 !important;
+  background-color: rgb(34 197 94 / var(--tw-bg-opacity)) !important;
+}
 .bg-opacity-40 {
   --tw-bg-opacity: 0.4 !important;
 }

--- a/src/ckanext-subakdc/ckanext/subakdc/templates/package/read_base.html
+++ b/src/ckanext-subakdc/ckanext/subakdc/templates/package/read_base.html
@@ -1,0 +1,9 @@
+{% ckan_extends %}
+
+{% block package_social %}
+{# Hide Social sharing links #}
+{% endblock %}
+
+{% block package_license %}
+{# Don't show the license here (now found under package/snippets/additional_info.html) #}
+{% endblock %}

--- a/src/ckanext-subakdc/ckanext/subakdc/templates/package/resource_read.html
+++ b/src/ckanext-subakdc/ckanext/subakdc/templates/package/resource_read.html
@@ -182,7 +182,7 @@
                 {% endblock %}
 
                 {% block resource_license %}
-                {% snippet "snippets/social.html" %}
+                    {# Hide social sharing links #}
                 {% endblock %}
             </div>
             {% endblock %}

--- a/src/ckanext-subakdc/ckanext/subakdc/templates/package/snippets/additional_info.html
+++ b/src/ckanext-subakdc/ckanext/subakdc/templates/package/snippets/additional_info.html
@@ -97,6 +97,23 @@
         <div>Source: <span class="font-body">{{ pkg_dict.url }}</span></div>
         {% endif %}
 
+        <div>License: <span class="font-body">
+        {% if 'license_url' in pkg_dict %}
+            <a href="{{ pkg_dict.license_url }}">{{ pkg_dict.license_title }}</a>
+        {% else %}
+            {% if pkg_dict.license_id %}
+                <span property="dc:rights">{{ pkg_dict.license_title }}</span>
+            {% else %}
+                <span>{{ _('No License Specified') }}</span>
+            {% endif %}
+        {% endif %}
+        {% if pkg_dict.isopen %}
+            <a class="px-1 py-px text-xs text-white no-underline bg-green-500 rounded-sm " href="http://opendefinition.org/okd/" title="{{ _('This dataset satisfies the Open Definition.') }}">
+                Open license
+            </a>
+        {% endif %}
+        </div>
+
         {% if pkg_dict.author %}
         <div>Contact: <span class="font-body">{{ pkg_dict.author }}</span></div>
         {% endif %}


### PR DESCRIPTION
- Hides social sharing links on dataset and resource view pages
- Moves license to the main metadata section on dataset view page
- Adds a green badge next to open-like licenses